### PR TITLE
Improved Mining Abilities Gui

### DIFF
--- a/render/guis/miningAbilitiesGui.js
+++ b/render/guis/miningAbilitiesGui.js
@@ -9,6 +9,7 @@ import constants from "../../util/constants"
 activeAbilities = undefined
 blegg = false
 tankCooldown = 1
+tank = ""
 activetimer = 0
 addAbility(constants.data.currentAbility, 0)
 
@@ -22,7 +23,8 @@ const miningAbilitiesGui = new BaseGui(["abilityGui", "miningabilities"], () => 
             return
     }
     let message = ``
-    message = `&e${activeAbilities.name}: &b${activeAbilities.timer}s\n`
+    let displaytimer = parseFloat(activeAbilities.timer).toFixed(2);
+    message = `&e${activeAbilities.name}: &b${displaytimer}s\n`
     if (activetimer > 0){
         message += `&aActive! &7(${activetimer}s)`
     }
@@ -37,18 +39,22 @@ function checkAreas()
 
 registerGui(miningAbilitiesGui)
 
-register("step", () => {
+register("tick", () => {
     if (constants.data.currentAbility != ""){// had to add currentAbility check otherwise on first time timer would just say 0 forever and give errors etc
         if(activetimer > 0){ //check if ability is active
-            activetimer--
+            activetimer -= .05
+            activetimer = Math.round(activetimer*100)/100
         }
-        if(activeAbilities.timer > 0)
-            activeAbilities.timer -= 1
+
+        if(activeAbilities.timer > 0) {
+            activeAbilities.timer -= .05
+            activeAbilities.timer = Math.round(activeAbilities.timer*100)/100
+        }
+            
         else if (activeAbilities.title.drawState == 0 && settings.miningAbilities)
             activeAbilities.title.draw()
     }
-
-}).setDelay(1)
+})
 
 
 //gets ability through you used your {ability name} message
@@ -105,15 +111,6 @@ register("chat", (abilityName) => {
 }).setCriteria(/&r&a&r&6([a-zA-Z ]+) &r&ais now available!&r/g)
 
 
-//gets cooldown from chat cause sometimes its more accurate
-register("chat", (cooldown) =>{
-    if (constants.data.currentAbility != ""){
-    addAbility(constants.data.currentAbility, cooldown)
-}
-}).setCriteria(/&r&cYour pickaxe ability is on cooldown for ([0-9]+)s.&r/g)
-
-
-
 function addAbility(abilityName, timer = 0)
 {
     let found = false
@@ -164,8 +161,7 @@ function addAbility(abilityName, timer = 0)
         default:
             maxTimer = 0
             maxActiveTimer = 0
-            break;
-        
+            break;   
     }
 
     //checks active pet for bal
@@ -186,7 +182,7 @@ function addAbility(abilityName, timer = 0)
     if (timer <= 0) {
 
         //calc timer based on reductions
-        timer = Math.round(maxTimer * (Bal * Skymall * tankCooldown))
+        timer = Math.trunc(maxTimer * (Bal * Skymall * tankCooldown))
     }
     
     

--- a/util/constants.js
+++ b/util/constants.js
@@ -186,6 +186,8 @@ export default constants = {
     isFiesta: false
 }
 
+let skymallPerkIndices = [10,19,28,37]
+
 register("gameLoad", () => {
     axios.get("https://ninjune.dev/api/cwinfo?new=true")
     .then((res) => {
@@ -196,10 +198,10 @@ register("gameLoad", () => {
 })
 
 
-register("chat", (lvl, pet, event) => {
+register("chat", (lvl, pet, skin, event) => {
     constants.data.currentPet = pet.toLowerCase()
     constants.data.save()
-}).setCriteria(/&cAutopet &eequipped your &.\[Lvl ([0-9]+)] &.([a-zA-Z]+)&e! &a&lVIEW RULE&r/g)
+}).setCriteria(/&cAutopet &eequipped your &.\[Lvl ([0-9]+)] &.([a-zA-Z ]+)([a-z0-9 ✦&]+e!) &a&lVIEW RULE&r/g)
 
 
 register("chat", (message, pet, event) => {
@@ -217,6 +219,49 @@ register("chat", (state, event) => {
     constants.data.save()
 }).setCriteria(/&r&.([a-zA-Z]+) Efficient Miner&r/g)
 
+
+register("step", () => {
+    let inventoryName = Player?.getContainer()?.getName()?.toString()
+    if(inventoryName == undefined || (!inventoryName.includes("Heart of the Mountain") && !inventoryName.includes("SkyBlock Menu"))) return
+
+    for (i = 0; i < skymallPerkIndices.length; i++)
+    {
+        let item = Player.getContainer().getStackInSlot(skymallPerkIndices[i])
+        if (item == null) continue
+
+        let itemName = item.getName().removeFormatting()
+        let lore = item?.getLore()
+        if(lore == undefined) return
+        
+        if(itemName.includes("Sky Mall")){
+            let skymallPerk = lore[15]?.removeFormatting()
+            skymallPerk = skymallPerk.substring(3, skymallPerk.length - 1)
+            let skymallEnabled = lore[17]?.removeFormatting()
+
+            if (!skymallEnabled.includes("ENABLED")) { 
+                constants.data.currentSkymall = ""
+                constants.data.save()
+                return 
+            }
+
+            let possible_perks = [
+                "-20% Pickaxe Ability cooldowns",
+                "Gain +100⸕ Mining Speed",
+                "Gain +50☘ Mining Fortune",
+                "Gain +15% more Powder while mining",
+                "Gain 5x Titanium drops",
+                "10x chance to find Golden and Diamond Goblins",
+            ]
+
+            if (!possible_perks.includes(skymallPerk)) {
+                return
+            }
+            constants.data.currentSkymall = skymallPerk
+            constants.data.save()
+            return
+        }
+    }
+}).setFps(2) // @CrazyTech4
 
 register("worldLoad", () => {
     Client.scheduleTask(20, updateRegisters);


### PR DESCRIPTION
- Check for skymall perk & if enabled when opening HOTM menu
- Fix autopet rule pet checker regex to work with skinned pets
- Fix error when using mining ability with a pickaxe without having used a mining ability with a drill with a fuel tank
- Improved pickable ability cooldown timer by changing it to count down per tick
- Removed chat pickaxe cooldown updating timer (this was not accurate)

May need to move skymall perk list to constants rather than having it listed in 2 places or move the hotm gui check to the skymall file.